### PR TITLE
feat: Add image support and button color options to Landing block

### DIFF
--- a/src/blocks/Landing/Component.tsx
+++ b/src/blocks/Landing/Component.tsx
@@ -1,11 +1,14 @@
+'use client'
+
 import { cn } from '@/utilities/ui'
 import React from 'react'
 import RichText from '@/components/RichText'
 import type { DefaultTypedEditorState } from '@payloadcms/richtext-lexical'
 
-import type { LandingBlock as LandingBlockProps, Page, Post } from '@/payload-types'
+import type { LandingBlock as LandingBlockProps, Page, Post, Media } from '@/payload-types'
 
 import { CMSLink } from '../../components/Link'
+import { Media as MediaComponent } from '../../components/Media'
 
 type Badge = {
   text?: string
@@ -13,20 +16,23 @@ type Badge = {
 }
 
 type LinkItem = {
-  type?: ('reference' | 'custom') | null
-  reference?: {
-    relationTo: 'pages' | 'posts'
-    value: string | number | Page | Post
-  } | null
-  url?: string | null
-  label?: string | null
-  appearance?: ('default' | 'outline') | null
-  newTab?: boolean | null
+  link?: {
+    type?: ('reference' | 'custom') | null
+    reference?: {
+      relationTo: 'pages' | 'posts'
+      value: string | number | Page | Post
+    } | null
+    url?: string | null
+    label?: string | null
+    appearance?: ('default' | 'outline' | 'red' | 'blue' | 'green') | null
+    newTab?: boolean | null
+  }
   id?: string | null
 }
 
 type Column = {
-  size?: 'oneThird' | 'half' | 'twoThirds' | 'full'
+  size?: 'oneFourth' | 'oneThird' | 'half' | 'twoThirds' | 'threeFourths' | 'full'
+  media?: string | Media | null
   badges?: Badge[] | null
   title?: string | null
   richText?: DefaultTypedEditorState
@@ -44,9 +50,11 @@ export const LandingBlock: React.FC<LandingBlockProps> = (props) => {
 
   const colsSpanClasses = {
     full: '12',
+    threeFourths: '9',
+    twoThirds: '8',
     half: '6',
     oneThird: '4',
-    twoThirds: '8',
+    oneFourth: '3',
   }
 
   const getBackgroundClass = () => {
@@ -68,15 +76,17 @@ export const LandingBlock: React.FC<LandingBlockProps> = (props) => {
           columns.map((col, index) => {
             if (!col) return null
             
-            const { links, richText, size, badges } = col
+            const { links, richText, size, badges, media } = col
             const colSize = size || 'full'
             const colSpanClass = colsSpanClasses[colSize as keyof typeof colsSpanClasses] || '12'
+            const hasMedia = media && typeof media === 'object'
+            const hasContent = richText || (links && links.length > 0) || (badges && badges.length > 0)
 
             return (
               <div
                 className={cn(
                   `col-span-1 sm:col-span-2 lg:col-span-${colSpanClass}`,
-                  'rounded-2xl shadow-lg p-4 sm:p-6',
+                  'rounded-2xl shadow-lg overflow-hidden',
                   getBackgroundClass(),
                   {
                     'sm:col-span-1': colSize === 'full',
@@ -85,35 +95,81 @@ export const LandingBlock: React.FC<LandingBlockProps> = (props) => {
                 )}
                 key={index}
               >
+                {/* Resim ve içerik yan yana düzeni */}
+                <div className={cn(
+                  'flex flex-col lg:flex-row h-full',
+                  {
+                    'lg:flex-row': hasMedia && hasContent,
+                    'flex-col': !hasMedia || !hasContent,
+                  }
+                )}>
+                  {/* Resim alanı */}
+                  {hasMedia && (
+                    <div className={cn(
+                      'relative',
+                      {
+                        'lg:w-1/2': hasContent && colSize !== 'full',
+                        'lg:w-1/3': hasContent && colSize === 'oneFourth',
+                        'lg:w-2/3': hasContent && colSize === 'threeFourths',
+                        'w-full': !hasContent,
+                      }
+                    )}>
+                      <MediaComponent
+                        resource={media}
+                        className="w-full h-full object-cover"
+                        imgClassName="w-full h-full object-cover"
+                        fill={false}
+                        size="(max-width: 768px) 100vw, 50vw"
+                      />
+                    </div>
+                  )}
 
+                  {/* İçerik alanı */}
+                  {hasContent && (
+                    <div className={cn(
+                      'p-4 sm:p-6 flex flex-col justify-start',
+                      {
+                        'lg:w-1/2': hasMedia && colSize !== 'full',
+                        'lg:w-2/3': hasMedia && colSize === 'oneFourth',
+                        'lg:w-1/3': hasMedia && colSize === 'threeFourths',
+                        'w-full': !hasMedia,
+                      }
+                    )}>
+                      {richText && (
+                        <div className={backgroundStyle === 'gradient' ? 'text-white text-xs mb-4' : 'text-black text-xs mb-4'}>
+                          <RichText data={richText} enableGutter={false} />
+                        </div>
+                      )}
 
-                {richText && (
-                  <div className={backgroundStyle === 'gradient' ? 'text-white text-sm' : 'text-black text-sm'}>
-                    <RichText data={richText} enableGutter={false} />
-                  </div>
-                )}
-
-                {links && Array.isArray(links) && links.length > 0 && (
-                  <div className="mt-6 flex flex-wrap justify-center items-center gap-3">
-                    {links.map((linkItem, linkIndex: number) => (
-                      <CMSLink key={linkIndex} {...linkItem} />
-                    ))}
-                  </div>
-                )}
-                {badges && Array.isArray(badges) && badges.length > 0 && (
-                  <div className="flex flex-wrap gap-2 mt-3 justify-center items-center">
-                    {badges.map((badgeItem, badgeIndex: number) => (
-                      <span 
-                        key={badgeIndex}
-                        className={cn(
-                          "text-xs font-semibold px-3 py-1.5 rounded-full uppercase tracking-wide bg-white text-blue-700 justify-center items-center shadow-lg border"
-                        )}
-                      >
-                        {badgeItem?.text || String(badgeItem)}
-                      </span>
-                    ))}
-                  </div>
-                )}
+                      {links && Array.isArray(links) && links.length > 0 && (
+                        <div className="mt-6 flex flex-wrap justify-center items-center gap-3">
+                          {links.map((linkItem, linkIndex: number) => (
+                            <CMSLink 
+                              key={linkIndex} 
+                              {...linkItem.link}
+                              appearance={linkItem.link?.appearance || 'default'}
+                            />
+                          ))}
+                        </div>
+                      )}
+                      
+                      {badges && Array.isArray(badges) && badges.length > 0 && (
+                        <div className="flex flex-wrap gap-2 mt-3 justify-center items-center">
+                          {badges.map((badgeItem, badgeIndex: number) => (
+                            <span 
+                              key={badgeIndex}
+                              className={cn(
+                                "text-xs font-semibold px-3 py-1.5 rounded-full uppercase tracking-wide bg-white text-blue-700 justify-center items-center shadow-lg border"
+                              )}
+                            >
+                              {badgeItem?.text || String(badgeItem)}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
               </div>
             )
           })}

--- a/src/blocks/Landing/config.ts
+++ b/src/blocks/Landing/config.ts
@@ -17,22 +17,37 @@ const columnFields: Field[] = [
     defaultValue: 'oneThird',
     options: [
       {
-        label: 'One Third',
+        label: 'One Fourth (1/4)',
+        value: 'oneFourth',
+      },
+      {
+        label: 'One Third (1/3)',
         value: 'oneThird',
       },
       {
-        label: 'Half',
+        label: 'Half (1/2)',
         value: 'half',
       },
       {
-        label: 'Two Thirds',
+        label: 'Two Thirds (2/3)',
         value: 'twoThirds',
+      },
+      {
+        label: 'Three Fourths (3/4)',
+        value: 'threeFourths',
       },
       {
         label: 'Full',
         value: 'full',
       },
     ],
+  },
+  {
+    name: 'media',
+    type: 'upload',
+    relationTo: 'media',
+    required: false,
+    label: 'Image',
   },
   {
     name: 'badges',

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import type { Page, Post } from '@/payload-types'
 
 type CMSLinkType = {
-  appearance?: 'inline' | ButtonProps['variant']
+  appearance?: 'inline' | ButtonProps['variant'] | 'default' | 'outline' | 'red' | 'blue' | 'green'
   children?: React.ReactNode
   className?: string
   label?: string | null
@@ -47,6 +47,26 @@ export const CMSLink: React.FC<CMSLinkType> = (props) => {
   const size = appearance === 'link' ? 'default' : sizeFromProps
   const newTabProps = newTab ? { rel: 'noopener noreferrer', target: '_blank' } : {}
 
+  // Map appearance values to Button variants
+  const getButtonVariant = (appearance: string | null): ButtonProps['variant'] => {
+    if (!appearance) return 'default'
+    
+    switch (appearance) {
+      case 'default':
+        return 'default'
+      case 'outline':
+        return 'outline'
+      case 'red':
+        return 'red'
+      case 'blue':
+        return 'blue'
+      case 'green':
+        return 'green'
+      default:
+        return appearance as ButtonProps['variant']
+    }
+  }
+
   /* Ensure we don't break any styles set by richText */
   if (appearance === 'inline') {
     return (
@@ -58,7 +78,7 @@ export const CMSLink: React.FC<CMSLinkType> = (props) => {
   }
 
   return (
-    <Button asChild className={className} size={size} variant={appearance}>
+    <Button asChild className={className} size={size} variant={getButtonVariant(appearance)}>
       <Link className={cn(className)} href={href || url || ''} onClick={(e) => onClick?.(e)} {...newTabProps}>
         {label && label}
         {children && children}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/utilities/ui"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 touch-feedback active:scale-95",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 touch-feedback active:scale-95 translate-y-[-4px]",
   {
     variants: {
       variant: {
@@ -19,6 +19,9 @@ const buttonVariants = cva(
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         candy: "bg-gradient-to-r from-purple-500 to-pink-500 text-white hover:from-purple-600 hover:to-pink-600 shadow-lg hover:shadow-xl transition-all duration-300",
+        red: "bg-red-500 text-white hover:bg-red-600 shadow-lg hover:shadow-xl transition-all duration-200",
+        blue: "bg-blue-500 text-white hover:bg-blue-600 shadow-lg hover:shadow-xl transition-all duration-200",
+        green: "bg-green-500 text-white hover:bg-green-600 shadow-lg hover:shadow-xl transition-all duration-200",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/fields/link.ts
+++ b/src/fields/link.ts
@@ -2,16 +2,28 @@ import type { Field, GroupField } from 'payload'
 
 import deepMerge from '@/utilities/deepMerge'
 
-export type LinkAppearances = 'default' | 'outline'
+export type LinkAppearances = 'default' | 'outline' | 'red' | 'blue' | 'green'
 
 export const appearanceOptions: Record<LinkAppearances, { label: string; value: string }> = {
   default: {
-    label: 'Default',
+    label: 'Default (Blue)',
     value: 'default',
   },
   outline: {
-    label: 'Outline',
+    label: 'Outline (Blue)',
     value: 'outline',
+  },
+  red: {
+    label: 'Red',
+    value: 'red',
+  },
+  blue: {
+    label: 'Blue',
+    value: 'blue',
+  },
+  green: {
+    label: 'Green',
+    value: 'green',
   },
 }
 
@@ -118,7 +130,13 @@ export const link: LinkType = ({ appearances, disableLabel = false, overrides = 
   }
 
   if (appearances !== false) {
-    let appearanceOptionsToUse = [appearanceOptions.default, appearanceOptions.outline]
+    let appearanceOptionsToUse = [
+      appearanceOptions.default, 
+      appearanceOptions.outline,
+      appearanceOptions.red,
+      appearanceOptions.blue,
+      appearanceOptions.green
+    ]
 
     if (appearances) {
       appearanceOptionsToUse = appearances.map((appearance) => appearanceOptions[appearance])

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -184,7 +184,7 @@ export interface Page {
             /**
              * Choose how the link should be rendered.
              */
-            appearance?: ('default' | 'outline') | null;
+            appearance?: ('default' | 'outline' | 'red' | 'blue' | 'green') | null;
           };
           id?: string | null;
         }[]
@@ -511,7 +511,7 @@ export interface ContentBlock {
           /**
            * Choose how the link should be rendered.
            */
-          appearance?: ('default' | 'outline') | null;
+          appearance?: ('default' | 'outline' | 'red' | 'blue' | 'green') | null;
         };
         id?: string | null;
       }[]
@@ -972,7 +972,8 @@ export interface LandingBlock {
   backgroundStyle?: ('gradient' | 'white' | 'gray') | null;
   columns?:
     | {
-        size?: ('oneThird' | 'half' | 'twoThirds' | 'full') | null;
+        size?: ('oneFourth' | 'oneThird' | 'half' | 'twoThirds' | 'threeFourths' | 'full') | null;
+        media?: (number | null) | Media;
         badges?:
           | {
               text: string;
@@ -1014,7 +1015,7 @@ export interface LandingBlock {
                 /**
                  * Choose how the link should be rendered.
                  */
-                appearance?: ('default' | 'outline') | null;
+                appearance?: ('default' | 'outline' | 'red' | 'blue' | 'green') | null;
               };
               id?: string | null;
             }[]
@@ -1578,6 +1579,7 @@ export interface LandingBlockSelect<T extends boolean = true> {
     | T
     | {
         size?: T;
+        media?: T;
         badges?:
           | T
           | {


### PR DESCRIPTION
- Added image selection feature to Landing block
- New size options: 1/4, 1/3, 1/2, 2/3, 3/4, full
- Responsive layout with image and content side by side
- Button color options: red, blue, green
- All buttons now have rounded-xl and translate-y-[-4px] effect
- Updated to client component
- Fixed build errors